### PR TITLE
Potential fixes for 2 code quality findings

### DIFF
--- a/UXTU4Linux/Assets/Presets/AMDFrameworkLaptop16Ryzen7040.py
+++ b/UXTU4Linux/Assets/Presets/AMDFrameworkLaptop16Ryzen7040.py
@@ -1,6 +1,6 @@
 PRESETS = {
     "Eco": "--tctl-temp=100 --apu-skin-temp=45 --stapm-limit=6000 --fast-limit=8000 --slow-limit=6000 --vrm-current=180000 --vrmmax-current=180000 --vrmsoc-current=180000 --vrmsocmax-current=180000 --vrmgfx-current=180000",
-    "BalPreset": "--tctl-temp=100 --apu-skin-temp=50 --stapm-limit=35000 --fast-limit=45000 --slow-limit=38000 --vrm-current=180000 --vrmmax-current=180000 --vrmsoc-current=180000 --vrmsocmax-current=180000 --vrmgfx-current=180000",
+    "Balance": "--tctl-temp=100 --apu-skin-temp=50 --stapm-limit=35000 --fast-limit=45000 --slow-limit=38000 --vrm-current=180000 --vrmmax-current=180000 --vrmsoc-current=180000 --vrmsocmax-current=180000 --vrmgfx-current=180000",
     "PerformancePreset": "--tctl-temp=100 --apu-skin-temp=50 --stapm-limit=45000 --fast-limit=55000 --slow-limit=50000 --vrm-current=180000 --vrmmax-current=180000 --vrmsoc-current=180000 --vrmsocmax-current=180000 --vrmgfx-current=180000",
     "Extreme": "--tctl-temp=100 --apu-skin-temp=50 --stapm-limit=55000 --fast-limit=70000 --slow-limit=65000 --vrm-current=180000 --vrmmax-current=180000 --vrmsoc-current=180000 --vrmsocmax-current=180000 --vrmgfx-current=180000",
     "AC": "--max-performance",

--- a/UXTU4Linux/Assets/Presets/AMDFrameworkLaptop16Ryzen7040.py
+++ b/UXTU4Linux/Assets/Presets/AMDFrameworkLaptop16Ryzen7040.py
@@ -2,7 +2,7 @@ PRESETS = {
     "Eco": "--tctl-temp=100 --apu-skin-temp=45 --stapm-limit=6000 --fast-limit=8000 --slow-limit=6000 --vrm-current=180000 --vrmmax-current=180000 --vrmsoc-current=180000 --vrmsocmax-current=180000 --vrmgfx-current=180000",
     "BalPreset": "--tctl-temp=100 --apu-skin-temp=50 --stapm-limit=35000 --fast-limit=45000 --slow-limit=38000 --vrm-current=180000 --vrmmax-current=180000 --vrmsoc-current=180000 --vrmsocmax-current=180000 --vrmgfx-current=180000",
     "PerformancePreset": "--tctl-temp=100 --apu-skin-temp=50 --stapm-limit=45000 --fast-limit=55000 --slow-limit=50000 --vrm-current=180000 --vrmmax-current=180000 --vrmsoc-current=180000 --vrmsocmax-current=180000 --vrmgfx-current=180000",
-    "ExtremePreset": "--tctl-temp=100 --apu-skin-temp=50 --stapm-limit=55000 --fast-limit=70000 --slow-limit=65000 --vrm-current=180000 --vrmmax-current=180000 --vrmsoc-current=180000 --vrmsocmax-current=180000 --vrmgfx-current=180000",
+    "Extreme": "--tctl-temp=100 --apu-skin-temp=50 --stapm-limit=55000 --fast-limit=70000 --slow-limit=65000 --vrm-current=180000 --vrmmax-current=180000 --vrmsoc-current=180000 --vrmsocmax-current=180000 --vrmgfx-current=180000",
     "AC": "--max-performance",
     "DC": "--power-saving"
 }


### PR DESCRIPTION
_This PR applies 2/3 suggestions from code quality [AI findings](https://github.com/HorizonUnix/UXTU4Linux/security/quality/ai-findings). 1 suggestion was skipped to avoid creating conflicts._

## Summary by Sourcery

Bug Fixes:
- Standardize preset names by renaming 'BalPreset' to 'Balance' and 'ExtremePreset' to 'Extreme' in the AMD Framework Laptop 16 Ryzen 7040 presets.