### PR TITLE
Potential fixes for 2 code quality findings

### DIFF
--- a/UXTU4Linux/Assets/Modules/daemon.py
+++ b/UXTU4Linux/Assets/Modules/daemon.py
@@ -410,6 +410,9 @@ class PowerDaemon:
         logging.info("Listening on %s", cfg.ZMQ_SOCKET_ADDR)
 
         stop_requested = False
+        # Poll every 500ms so shutdown signals are handled within at most ~0.5s
+        # while avoiding a tight loop that would wake the CPU too frequently.
+        poll_timeout_ms = 500
 
         def _sig_handler(*_):
             nonlocal stop_requested
@@ -424,7 +427,7 @@ class PowerDaemon:
                 self._stop_loop()
                 break
 
-            if not sock.poll(500):
+            if not sock.poll(poll_timeout_ms):
                 continue
 
             raw  = sock.recv_string()

--- a/UXTU4Linux/Assets/Modules/daemon.py
+++ b/UXTU4Linux/Assets/Modules/daemon.py
@@ -172,8 +172,8 @@ def _load_saved_preset() -> PresetState | None:
 
     reapply  = cfg.get("Settings", "ReApply",     "0") == "1"
     dynamic  = cfg.get("Settings", "DynamicMode", "0") == "1"
-    cfg_default = int(cfg.get("Settings", "Time", "3"))
-    interval = _parse_interval(cfg.get("Settings", "Time", str(cfg_default)), cfg_default)
+    cfg_default = _parse_interval(cfg.get("Settings", "Time", "3"), 3)
+    interval = _parse_interval(cfg.get("Settings", "Time", "3"), cfg_default)
 
     return PresetState(
         mode=user_mode,


### PR DESCRIPTION
_This PR applies 2/2 suggestions from code quality [AI findings](https://github.com/HorizonUnix/UXTU4Linux/security/quality/ai-findings)._

## Summary by Sourcery

Apply code quality improvements to daemon preset loading and message polling behavior.

Enhancements:
- Simplify preset interval configuration by consistently using the interval parsing helper when reading settings.
- Introduce a named polling timeout constant to document and control ZeroMQ socket poll frequency and shutdown responsiveness.