### PR TITLE
Potential fixes for 2 code quality findings

### DIFF
--- a/UXTU4Linux/Assets/Modules/daemon.py
+++ b/UXTU4Linux/Assets/Modules/daemon.py
@@ -286,7 +286,7 @@ class PowerDaemon:
         args = msg.get("args", "")
         mode = msg.get("mode", "Unknown")
 
-        cfg_default = int(cfg.get("Settings", "Time", "3"))
+        cfg_default = _parse_interval(cfg.get("Settings", "Time", "3"), 3)
         interval    = _parse_interval(msg.get("interval", cfg_default), cfg_default)
 
         dynamic = bool(msg.get("dynamic", False))

--- a/UXTU4Linux/Assets/Modules/daemon.py
+++ b/UXTU4Linux/Assets/Modules/daemon.py
@@ -173,7 +173,7 @@ def _load_saved_preset() -> PresetState | None:
     reapply  = cfg.get("Settings", "ReApply",     "0") == "1"
     dynamic  = cfg.get("Settings", "DynamicMode", "0") == "1"
     cfg_default = _parse_interval(cfg.get("Settings", "Time", "3"), 3)
-    interval = _parse_interval(cfg.get("Settings", "Time", "3"), cfg_default)
+    interval = cfg_default
 
     return PresetState(
         mode=user_mode,


### PR DESCRIPTION
_This PR applies 2/2 suggestions from code quality [AI findings](https://github.com/HorizonUnix/UXTU4Linux/security/quality/ai-findings)._

## Summary by Sourcery

Align interval configuration handling in the daemon with the parsed default interval value.

Bug Fixes:
- Ensure the saved preset interval uses the already parsed default interval instead of re-parsing the configuration value.
- Use the same interval parsing helper for the default loop interval to avoid invalid or inconsistent configuration values.