### PR TITLE
Potential fix for 1 code quality finding

### DIFF
--- a/UXTU4Linux/Assets/Modules/daemon.py
+++ b/UXTU4Linux/Assets/Modules/daemon.py
@@ -125,7 +125,7 @@ def _run_ryzenadj(args: str, mode: str) -> str:
             [cfg.RYZENADJ] + payload,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            timeout=10,
+            timeout=COMMAND_TIMEOUT_SECONDS,
         )
     except subprocess.TimeoutExpired:
         logging.error("ryzenadj timed out")


### PR DESCRIPTION
_This PR applies 1/4 suggestions from code quality [AI findings](https://github.com/HorizonUnix/UXTU4Linux/security/quality/ai-findings). 3 suggestions were skipped to avoid creating conflicts._

## Summary by Sourcery

Enhancements:
- Replace the hard-coded ryzenadj subprocess timeout with the shared COMMAND_TIMEOUT_SECONDS constant.