### PR TITLE
Potential fix for 1 code quality finding

### DIFF
--- a/UXTU4Linux/Assets/Modules/daemon.py
+++ b/UXTU4Linux/Assets/Modules/daemon.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass
 
 _HERE = os.path.dirname(os.path.realpath(__file__))
 _ROOT = os.path.dirname(os.path.dirname(_HERE))
+ZMQ_POLL_TIMEOUT_MS = 500
 if _ROOT not in sys.path:
     sys.path.insert(0, _ROOT)
 
@@ -424,7 +425,7 @@ class PowerDaemon:
         stop_requested = threading.Event()
         # Poll every 500ms so shutdown signals are handled within at most ~0.5s
         # while avoiding a tight loop that would wake the CPU too frequently.
-        poll_timeout_ms = 500
+        poll_timeout_ms = ZMQ_POLL_TIMEOUT_MS
 
         signal.signal(signal.SIGTERM, lambda *args: self._sig_handler(stop_requested, *args))
         signal.signal(signal.SIGINT,  lambda *args: self._sig_handler(stop_requested, *args))


### PR DESCRIPTION
_This PR applies 1/3 suggestions from code quality [AI findings](https://github.com/HorizonUnix/UXTU4Linux/security/quality/ai-findings). 2 suggestions were skipped to avoid creating conflicts._

## Summary by Sourcery

Enhancements:
- Introduce a module-level ZMQ poll timeout constant and reference it in the daemon run loop instead of a hard-coded literal.